### PR TITLE
Deploy Web

### DIFF
--- a/web/DEPLOY.md
+++ b/web/DEPLOY.md
@@ -1,0 +1,34 @@
+# Deployment Instructions
+
+## The app is ran on our digital ocean instance by modifying the systemd daemon files and ran from systemctl as such
+
+```
+Digital Ocean Info:
+ip: 137.184.178.55
+password: ASK_DEVS
+```
+
+- Our project is located at `/home/django/selecto`
+- We use Gunicorn for mangaging the running of our service
+- You can find these settings here: `/etc/systemd/system/gunicorn.service` 
+- You can also change nginx routing traffic by editing `/etc/nginx/sites-enabled/default`
+- Don't forget to run `pip install -r requirements.txt`
+
+If you made changes to systemd files... you need to run this to load changes:
+```
+vim /etc/systemd/system/gunicorn.service
+sudo systemctl daemon-reload
+```
+
+## When you want to deploy...
+
+You can stop gunicorn using:
+```
+sudo systemctl stop gunicorn
+```
+
+And you can run gunicorn using...
+```
+sudo systemctl start gunicorn
+sudo systemctl status gunicorn
+```

--- a/web/selecto/selecto/settings.py
+++ b/web/selecto/selecto/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = "django-insecure-)k4%*91+#l2xekl!c-#area#5(tum20t9mj%g3gymw8hdld0ws
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["137.184.178.55"]
 
 
 # Application definition

--- a/web/selecto/selecto/settings.py
+++ b/web/selecto/selecto/settings.py
@@ -25,8 +25,7 @@ SECRET_KEY = "django-insecure-)k4%*91+#l2xekl!c-#area#5(tum20t9mj%g3gymw8hdld0ws
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["137.184.178.55"]
-
+ALLOWED_HOSTS = ["137.184.178.55", "selecto.pro", "www.selecto.pro", "http://www.selecto.pro", "https://www.selecto.pro"]
 
 # Application definition
 


### PR DESCRIPTION
Updated deployment instructions for Digital Ocean instance. Added instructions on managing Gunicorn process and Nginx routing. Check README for details.


Also added in digital ocean droplet as allowable host.

Other things to do:
### Get production-ready
- [Set up a non-root user for day-to-day use](https://www.digitalocean.com/community/tutorials/initial-server-setup-with-ubuntu-18-04)
- [Set up a DigitalOcean cloud firewall](https://www.digitalocean.com/docs/networking/firewalls/) (they're free).
- [Register a custom domain](https://www.digitalocean.com/docs/networking/dns/quickstart/)
- Have data needs? You can mount a [volume](https://www.digitalocean.com/docs/volumes/) (up to 16TB) to this server to expand the filesyem, provision a [database cluster](https://www.digitalocean.com/docs/databases/) (that runs MySQL, Redis, or PostgreSQL), or use a [Space](https://www.digitalocean.com/docs/spaces/), which is an S3-compatible bucket for storing objects.