### PR TITLE
Start Using Dotenv for Openapi and Fix Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ install:
 	pip install -r web/selecto/requirements.txt
 
 test:
-	pytest -rsk web/selecto/tests/
+	pytest -rs web/selecto/tests/

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ install:
 	pip install -r web/selecto/requirements.txt
 
 test:
-	pytest -k web/selecto/tests/
+	pytest -rsk web/selecto/tests/

--- a/web/selecto/products/views.py
+++ b/web/selecto/products/views.py
@@ -4,9 +4,13 @@ from django.template import loader
 from .models import Product, Review
 from random import randint
 import openai
-from key import OPENAI_API_KEY
+from dotenv import load_dotenv
+import os
 
-openai.api_key = OPENAI_API_KEY
+# Load environment variables from .env file
+load_dotenv()
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 # Create your views here.
 

--- a/web/selecto/requirements.txt
+++ b/web/selecto/requirements.txt
@@ -2,3 +2,4 @@ django==4.1.7
 pytest==7.2.2
 pytest-django==4.5.2
 openai===0.27.4
+python-dotenv===1.0.0


### PR DESCRIPTION
This PR fixes our existing tests so that they are no longer testing. It also allows us to use a .env file to put our openapi key in.