### PR TITLE
Adds Tox for building, and Updates README to Includes Getting Started Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .sources
 .venv
 db.sqlite3
+/venv

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Run the development web server
 run:
-	python web/selecto/manage.py runserver 8080
+	python web/selecto/manage.py runserver 8000
 
 # Apply database migrations
 migrate:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,46 @@
 Selecto is a Python webproject which makes it easy to filter and search for various products online. With enhanced filtering, we can find the best product for you!
 
 
-## Planned Feature-set:
-- Enhanced Amazon Search
-    - remove duplicate products
-    - allow to set exact pricing or shipping requirements
-    - only show significantly different products
-    - combine style selection
-- Enhanced Reviews
-    - show the best Amazon reviews
-    - display videos related to a given product
-    - shows other reviews Online from places like CNET, Wirecutter, or LifeHacker
+# Getting Started
+This project is built using tox. This allows us to build in both Unix and Windows enviroments. To run tox, please follow the below instructions:
 
+## Setup virtual environment
+Here is an example on using venv.
+1. Please up the terminal and naviate to the project root directory. Then run this command to setup your venv environment.
+    ```
+    python -m venv venv
+    ```
+2. If you are on **WINDOWS** please run this to activate this venv environment.
+    ```
+    venv\Scripts\activate     # On Windows
+    ```
+    If you are on **MACOS/UNIX** please run this to activate this venv environment.
+    ```
+    source venv/bin/activate  # On macOS/Linux
+    ```
+
+## Using Tox
+1. Ensure that you have Python and pip installed on your system. If you don't have them installed, download Python from the official website (https://www.python.org/downloads/) and follow the installation instructions for your operating system.
+2. Install tox using pip:
+    ```
+    pip install tox
+    ```
+3. Run the commands specified in the tox.ini file using the following syntax:
+    ```
+    tox -e <command>
+    ```
+    Replace <command> with the desired command from the tox.ini file, such as run, migrate, install, test, or init_db.
+
+## Initalize DB
+1. Run the commands 
+    ```
+    tox -e install
+    tox -e init_db
+    ```
+    This will initalize the db so that you can run the server.
+
+## Run server
+1. To run the server, please use 
+    ```
+    tox -e run
+    ```

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,33 @@
+[tox]
+envlist = run, migrate, install, test, init_db
+skipsdist = True
+
+[testenv]
+basepython = python
+setenv =
+    PYTHONPATH = {toxinidir}/web/selecto
+deps =
+    -r{toxinidir}/web/selecto/requirements.txt
+
+[testenv:run]
+commands =
+    python {toxinidir}/web/selecto/manage.py runserver 8000
+
+[testenv:migrate]
+commands =
+    python {toxinidir}/web/selecto/manage.py migrate
+
+[testenv:install]
+commands =
+    pip install -r {toxinidir}/web/selecto/requirements.txt
+
+[testenv:test]
+deps =
+    -r{toxinidir}/web/selecto/requirements.txt
+    pytest
+commands =
+    pytest -rs tests/
+
+[testenv:init_db]
+commands =
+    python {toxinidir}/web/selecto/manage.py init_db


### PR DESCRIPTION
This adds Tox so that we have platform agnostic builds. It is a bit slow, but the builds are reproducable.

The base README.md now includes instructions on how to configure tox on your local system.