### PR TITLE
Remove -e Flag for Tox Commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ Here is an example on using venv.
     ```
 3. Run the commands specified in the tox.ini file using the following syntax:
     ```
-    tox -e <command>
+    tox <command>
     ```
     Replace <command> with the desired command from the tox.ini file, such as run, migrate, install, test, or init_db.
 
 ## Initalize DB
 1. Run the commands 
     ```
-    tox -e install
-    tox -e init_db
+    tox install
+    tox init_db
     ```
     This will initalize the db so that you can run the server.
 
 ## Run server
 1. To run the server, please use 
     ```
-    tox -e run
+    tox run
     ```


### PR DESCRIPTION
Apparently you don't need `-e` for tox. It is for specifying environment. I wasn't using ti. And apparently, it fails sometimes if an argument isn't properly passed. It is better to just delete it. 