### PR TITLE
changed 'tox run' to 'tox runserver'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ Here is an example on using venv.
 ## Run server
 1. To run the server, please use 
     ```
-    tox -e run
+    tox -e runserver
     ```

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = run, migrate, install, test, init_db
+envlist = runserver, migrate, install, test, init_db
 skipsdist = True
 
 [testenv]
@@ -9,7 +9,7 @@ setenv =
 deps =
     -r{toxinidir}/web/selecto/requirements.txt
 
-[testenv:run]
+[testenv:runserver]
 commands =
     python {toxinidir}/web/selecto/manage.py runserver 8000
 


### PR DESCRIPTION
Had an issue with 'tox run' that I believe was caused because 'tox run' is already a command so (chatgpt):

The reason for this is that tox treats the run command as a special environment, not as a regular command. When you run tox run, tox will run all the commands listed under the run environment in your tox.ini file.

If you name a command as run in your tox.ini file, it will be included in the tox run command by default, which may not be what you intended. Additionally, if you try to run the run command explicitly using tox -e run, it may not work as expected, since tox treats run as a special environment, not a regular command.

Therefore, it's best to avoid using the name run for any commands in your tox.ini file to avoid any potential conflicts with tox itself.