### PR TITLE
Simplify tox init so that ENV settings doesn't break

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,13 @@ skipsdist = True
 basepython = python
 setenv =
     PYTHONPATH = {toxinidir}/web/selecto
+    ENVIRONMENT = {env:ENVIRONMENT:dev}
 deps =
     -r{toxinidir}/web/selecto/requirements.txt
 
 [testenv:runserver]
 commands =
-    ENVIRONMENT={env:ENVIRONMENT:dev} python {toxinidir}/web/selecto/manage.py runserver 8000
+    python {toxinidir}/web/selecto/manage.py runserver 8000
 
 [testenv:migrate]
 commands =
@@ -30,4 +31,4 @@ commands =
 
 [testenv:init_db]
 commands =
-    ENVIRONMENT={env:ENVIRONMENT:dev} python {toxinidir}/web/selecto/manage.py init_db
+    python {toxinidir}/web/selecto/manage.py init_db

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,9 @@ commands =
 [testenv:init_db]
 commands =
     python {toxinidir}/web/selecto/manage.py init_db
+
+[testenv:runserver_prod]
+setenv =
+    ENVIRONMENT = prod
+commands =
+    python {toxinidir}/web/selecto/manage.py runserver 8000


### PR DESCRIPTION
This makes the prod config work a bit better on UNIX systems. I'm unsure if this works on windows systems. 🤔 We need a way to make sure this works on all systems well. I wonder how I can do that.