### PR TITLE
Add Black as Linter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = runserver, migrate, install, test, init_db
+envlist = install, black, test
 skipsdist = True
 
 [testenv]
@@ -28,6 +28,12 @@ deps =
     pytest
 commands =
     pytest -rs {toxinidir}/web/selecto/tests/
+
+[testenv:black]
+deps =
+    black
+commands =
+    black --check {toxinidir}/web
 
 [testenv:init_db]
 commands =


### PR DESCRIPTION
This adds Black as a linter for our python project.

This also changes the default behavior of when we run tox by itself. We only want to run test and lint by default.