### PR TITLE
Add new permission, and additional tests

### DIFF
--- a/web/selecto/products/permissions.py
+++ b/web/selecto/products/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework import permissions
+
+class IsAdminOrReadOnly(permissions.IsAdminUser):
+    def has_permission(self, request, view):
+        # Check if the request method is safe (GET, HEAD, OPTIONS)
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # For non-safe methods, delegate the permission check to IsAdminUser
+        return super().has_permission(request, view)

--- a/web/selecto/products/serializers.py
+++ b/web/selecto/products/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from products.models import Product, ProductPhoto, Review
 from rest_framework import permissions
 from django.contrib.auth.models import User
+from .permissions import IsAdminOrReadOnly
 
 '''
 The ModelSerializer class handles a lot of boilerplating, including:
@@ -9,7 +10,7 @@ The ModelSerializer class handles a lot of boilerplating, including:
     - simple default implementations for  the create() and update() methods
 '''
 class ProductSerializer(serializers.HyperlinkedModelSerializer):
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAdminOrReadOnly]
     
     class Meta:
         # choose the model product from products.models
@@ -18,7 +19,7 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
         fields = ['pk', 'product_name', 'product_description']
 
 class ReviewSerializer(serializers.HyperlinkedModelSerializer):
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAdminOrReadOnly]
     '''
     While new fields can be defined here to display,
     Hyperlinkedrelatedfields require a field to be defined in the model.
@@ -36,6 +37,7 @@ class ReviewSerializer(serializers.HyperlinkedModelSerializer):
         fields = ['pk', 'review_related_product', 'review_content', 'review_publish_date']
 
 class UserSerializer(serializers.ModelSerializer):
+    permission_classes = [permissions.IsAdminUser]
 
     class Meta:
         model = User

--- a/web/selecto/products/views.py
+++ b/web/selecto/products/views.py
@@ -13,6 +13,7 @@ from config import GOOGLE_CLIENT_ID
 from . import openai_module
 from products.serializers import ProductSerializer, ReviewSerializer, UserSerializer
 from rest_framework import generics, renderers, permissions
+from .permissions import IsAdminOrReadOnly
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -149,22 +150,22 @@ PUT, PATCH, and DELETE requests.
 class ApiProductList(generics.ListCreateAPIView):
     queryset = get_all_products()
     serializer_class = ProductSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAdminOrReadOnly]
 
 class ApiProductDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = get_all_products()
     serializer_class = ProductSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAdminOrReadOnly]
 
 class ApiReviewList(generics.ListCreateAPIView):
     queryset = Review.objects.all()
     serializer_class = ReviewSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAdminOrReadOnly]
 
 class ApiReviewDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Review.objects.all()
     serializer_class = ReviewSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAdminOrReadOnly]
 
 class UserList(generics.ListAPIView):
     # While the other classes had models whose ordering was defined through

--- a/web/selecto/tests/test_permissions.py
+++ b/web/selecto/tests/test_permissions.py
@@ -1,0 +1,36 @@
+from django.contrib.auth.models import User
+from rest_framework.test import APIRequestFactory
+from products.permissions import IsAdminOrReadOnly
+import pytest
+
+factory = APIRequestFactory()
+
+@pytest.mark.django_db
+def test_is_admin_or_read_only_permission():
+    # Create an instance of the permission class
+    permission = IsAdminOrReadOnly()
+
+    # Create a user (non-admin)
+    user = User.objects.create_user(username='testuser', password='testpassword')
+
+    # Create a request for a safe method (GET)
+    request = factory.get('/example/')
+    request.user = user
+
+    # Assert that the permission allows access for safe methods
+    assert permission.has_permission(request, user) is True
+
+    # Create a request for a non-safe method (POST)
+    request = factory.post('/example/')
+    request.user = user
+
+    # Assert that the permission denies access for non-safe methods for non-admin users
+    assert permission.has_permission(request, user) is False
+
+    # Make the user an admin
+    user.is_staff = True
+    user.save()
+
+    # Assert that the permission allows access for non-safe methods for admin users
+    assert permission.has_permission(request, None) is True
+    user.delete()


### PR DESCRIPTION
Without this PR any user (including ones made through the google signin feature) can post, update, and delete any entries for most of our data. This adds a new permission where anyone can access the data but not post to it. 

I also added tests to make sure that user data was only accessible to admins (IsAdminUser), which checks for if an 'is_staff' Boolean is true.